### PR TITLE
Set up frontend structure with React components and Material-UI

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000/api/v1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "mining-calculations-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.18",
+    "@mui/material": "^5.14.18",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^27.5.2",
+    "@types/node": "^16.18.61",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "axios": "^1.6.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "recharts": "^2.9.3",
+    "typescript": "^4.9.5",
+    "web-vitals": "^2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import { ThemeProvider } from '@mui/material';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { theme } from './theme/theme';
 import DashboardLayout from './components/Dashboard/DashboardLayout';
 
-const queryClient = new QueryClient();
-
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <DashboardLayout />
-      </ThemeProvider>
-    </QueryClientProvider>
+    <ThemeProvider theme={theme}>
+      <DashboardLayout />
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/Analytics/MarketAnalysis.tsx
+++ b/frontend/src/components/Analytics/MarketAnalysis.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+
+const MarketAnalysis = () => {
+  return (
+    <Box>
+      <Typography variant="h6">Market Analysis</Typography>
+    </Box>
+  );
+};
+
+export default MarketAnalysis;

--- a/frontend/src/components/Analytics/ROICalculator.tsx
+++ b/frontend/src/components/Analytics/ROICalculator.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import { Typography, Box } from '@mui/material';
 
 const ROICalculator = () => {
-  return <div></div>;
+  return (
+    <Box>
+      <Typography variant="h6">ROI Calculator</Typography>
+    </Box>
+  );
 };
 
 export default ROICalculator;

--- a/frontend/src/components/Charts/ProfitabilityChart.tsx
+++ b/frontend/src/components/Charts/ProfitabilityChart.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+
+const ProfitabilityChart = () => {
+  return (
+    <Box>
+      <Typography variant="h6">Profitability Chart</Typography>
+    </Box>
+  );
+};
+
+export default ProfitabilityChart;

--- a/frontend/src/components/Dashboard/NetworkStats.tsx
+++ b/frontend/src/components/Dashboard/NetworkStats.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+
+const NetworkStats = () => {
+  return (
+    <Box>
+      <Typography variant="h6">Network Statistics</Typography>
+    </Box>
+  );
+};
+
+export default NetworkStats;

--- a/frontend/src/components/Miners/MinersList.tsx
+++ b/frontend/src/components/Miners/MinersList.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import { Typography, Box } from '@mui/material';
 
 const MinersList = () => {
-  return <div></div>;
+  return (
+    <Box>
+      <Typography variant="h6">Miners List</Typography>
+    </Box>
+  );
 };
 
 export default MinersList;


### PR DESCRIPTION
This PR sets up the initial frontend structure for the mining calculations application. Changes include:

- Created base App component with Material-UI ThemeProvider
- Added component structure for:
  - Dashboard (NetworkStats)
  - Miners (MinersList)
  - Analytics (ROICalculator, MarketAnalysis)
  - Charts (ProfitabilityChart)
- Set up environment configuration with API URL
- Added package.json with required dependencies:
  - Material-UI components and icons
  - React 18
  - TypeScript
  - Recharts for data visualization
  - Axios for API calls

All components are currently skeleton implementations with basic Typography elements, ready for further development.